### PR TITLE
[CIFlow] Mark ambiguous commands as confusing

### DIFF
--- a/src/ciflow-bot.ts
+++ b/src/ciflow-bot.ts
@@ -161,7 +161,7 @@ export class CIFlowBot {
         {
           event: this.event,
           owner: this.owner,
-          command_args: this.command_args,
+          command_args: this.command_args
         },
         'ciflow dispatch is confused!'
       );
@@ -236,7 +236,7 @@ export class CIFlowBot {
     });
   }
 
-  async postReaction() : Promise<void> {
+  async postReaction(): Promise<void> {
     if (this.event === CIFlowBot.event_issue_comment) {
       await this.ctx.github.reactions.createForIssueComment({
         comment_id: this.comment_id,
@@ -344,18 +344,20 @@ export class CIFlowBot {
           return false;
         }
         // `rerun` command is confusing if it has any other subcommand
-        if (this.command_args._.length != 1) {
+        if (this.command_args._.length !== 1) {
           this.confusing_command = true;
         }
-        const l_type = typeof this.command_args.l;
+        const lType = typeof this.command_args.l;
         // `rerun` does not accept any other options but "-l"
         // So, mark command as confusing if it has any other arguments than l
-        if (l_type === 'undefined') {
-          this.confusing_command = this.confusing_command || (commandArgsLength != 1);
+        if (lType === 'undefined') {
+          this.confusing_command =
+            this.confusing_command || commandArgsLength !== 1;
           break;
         }
-        this.confusing_command = this.confusing_command || (commandArgsLength != 2);
-        if (l_type !== 'object') {
+        this.confusing_command =
+          this.confusing_command || commandArgsLength !== 2;
+        if (lType !== 'object') {
           // Arg can be string, integer or boolean
           this.command_args.l = [this.command_args.l];
         }

--- a/src/ciflow-bot.ts
+++ b/src/ciflow-bot.ts
@@ -78,6 +78,7 @@ export class CIFlowBot {
   comment_author = '';
   comment_author_permission = '';
   comment_body = '';
+  confusing_command = false;
   dispatch_labels: string[] = [];
   dispatch_strategies = [CIFlowBot.strategy_add_default_labels];
   default_labels = CIFlowBot.defaultLabels;
@@ -154,6 +155,18 @@ export class CIFlowBot {
   }
 
   async dispatch(): Promise<void> {
+    if (this.confusing_command) {
+      await this.postReaction();
+      this.ctx.log.info(
+        {
+          event: this.event,
+          owner: this.owner,
+          command_args: this.command_args,
+        },
+        'ciflow dispatch is confused!'
+      );
+      return;
+    }
     // Dispatch_strategies is like a pipeline of functions we can apply to
     // change `this.dispatch_labels`. We can add other dispatch algorithms
     // based on the ctx or user instructions.
@@ -223,6 +236,17 @@ export class CIFlowBot {
     });
   }
 
+  async postReaction() : Promise<void> {
+    if (this.event === CIFlowBot.event_issue_comment) {
+      await this.ctx.github.reactions.createForIssueComment({
+        comment_id: this.comment_id,
+        content: this.confusing_command ? 'confused' : '+1',
+        owner: this.owner,
+        repo: this.repo
+      });
+    }
+  }
+
   // signalGithub triggers a dispatch (if needed) as well as reacts to the comment
   async signalGithub(): Promise<void> {
     if (
@@ -248,14 +272,7 @@ export class CIFlowBot {
       await this.triggerGHADispatch();
     }
 
-    if (this.event === CIFlowBot.event_issue_comment) {
-      await this.ctx.github.reactions.createForIssueComment({
-        comment_id: this.comment_id,
-        content: '+1',
-        owner: this.owner,
-        repo: this.repo
-      });
-    }
+    await this.postReaction();
 
     await new Ruleset(
       this.ctx,
@@ -321,14 +338,35 @@ export class CIFlowBot {
         if (this.command_args._.length === 0) {
           return false;
         }
+        const commandArgsLength = Object.keys(this.command_args).length;
         const subCommand = this.command_args._[0];
         if (subCommand !== CIFlowBot.command_ciflow_rerun) {
           return false;
         }
-        if (typeof this.command_args.l === 'string') {
+        // `rerun` command is confusing if it has any other subcommand
+        if (this.command_args._.length != 1) {
+          this.confusing_command = true;
+        }
+        const l_type = typeof this.command_args.l;
+        // `rerun` does not accept any other options but "-l"
+        // So, mark command as confusing if it has any other arguments than l
+        if (l_type === 'undefined') {
+          this.confusing_command = this.confusing_command || (commandArgsLength != 1);
+          break;
+        }
+        this.confusing_command = this.confusing_command || (commandArgsLength != 2);
+        if (l_type !== 'object') {
+          // Arg can be string, integer or boolean
           this.command_args.l = [this.command_args.l];
         }
-        for (const label of this.command_args.l || []) {
+        for (const label of this.command_args.l) {
+          if (typeof label !== 'string') {
+            this.confusing_command = true;
+            continue;
+          }
+          if (!label.startsWith(CIFlowBot.pr_label_prefix)) {
+            this.confusing_command = true;
+          }
           this.dispatch_labels.push(label);
         }
         break;
@@ -417,6 +455,7 @@ export class CIFlowBot {
         pr_number: this.pr_number,
         repo: this.repo,
         default_labels: this.default_labels,
+        confusing_command: this.confusing_command,
         valid: isValid
       },
       'ciflow dispatch started!'

--- a/test/auto-cc-bot.test.ts
+++ b/test/auto-cc-bot.test.ts
@@ -13,15 +13,17 @@ describe('auto-cc-bot', () => {
     probot.load(myProbotApp);
   });
 
-  test('no-op when tracker is missing', async() => {
+  test('no-op when tracker is missing', async () => {
     nock('https://api.github.com')
-      .get('/repos/ezyang/testing-ideal-computing-machine/contents/.github/pytorch-probot.yml')
-      .reply(404, { message: "There is nothing here"});
+      .get(
+        '/repos/ezyang/testing-ideal-computing-machine/contents/.github/pytorch-probot.yml'
+      )
+      .reply(404, {message: 'There is nothing here'});
 
     // Not sure why, but ProBot will look here if config is missing in the actual repo
     nock('https://api.github.com')
       .get('/repos/ezyang/.github/contents/.github/pytorch-probot.yml')
-      .reply(404, { message: "There is nothing here"});
+      .reply(404, {message: 'There is nothing here'});
 
     const payload = require('./fixtures/issues.labeled'); // testlabel
     await probot.receive({name: 'issues', payload, id: '2'});
@@ -57,7 +59,7 @@ Some header text
 
     scope.done();
   });
-  test('add a cc to issue with empty body', async() => {
+  test('add a cc to issue with empty body', async () => {
     nock('https://api.github.com')
       .post('/app/installations/2/access_tokens')
       .reply(200, {token: 'test'});

--- a/test/auto-label-bot.test.ts
+++ b/test/auto-label-bot.test.ts
@@ -71,13 +71,10 @@ describe('auto-label-bot', () => {
     payload['pull_request']['labels'] = [];
 
     const scope = nock('https://api.github.com')
-      .post(
-        '/repos/zhouzhuojie/gha-ci-playground/issues/31/labels',
-        body => {
-          expect(body).toMatchObject(['module: rocm']);
-          return true;
-        }
-      )
+      .post('/repos/zhouzhuojie/gha-ci-playground/issues/31/labels', body => {
+        expect(body).toMatchObject(['module: rocm']);
+        return true;
+      })
       .reply(200);
 
     await probot.receive({name: 'pull_request', payload: payload, id: '2'});

--- a/test/ciflow-bot.test.ts
+++ b/test/ciflow-bot.test.ts
@@ -83,7 +83,7 @@ describe('CIFlowBot Unit Tests', () => {
     const invalidComments = [
       `invalid`,
       `@${CIFlowBot.bot_assignee}`, // without commands appended after the @assignee
-      `@${CIFlowBot.bot_assignee} ciflow`, // without subcommand rerun
+      `@${CIFlowBot.bot_assignee} ciflow` // without subcommand rerun
     ];
     test.each(invalidComments)(
       'invalid comment: %s',
@@ -171,11 +171,14 @@ describe('CIFlowBot Integration Tests', () => {
       .post('/app/installations/2/access_tokens')
       .reply(200, {token: 'test'});
 
-    nockTracker(`
+    nockTracker(
+      `
                 @zzj-bot
                 @octocat ciflow/default cats
                 -@opt-out-users`,
-                'pytorch/pytorch', 'ciflow_tracking_issue: 6');
+      'pytorch/pytorch',
+      'ciflow_tracking_issue: 6'
+    );
 
     jest.spyOn(Ruleset.prototype, 'upsertRootComment').mockReturnValue(null);
   });
@@ -234,7 +237,7 @@ describe('CIFlowBot Integration Tests', () => {
     event.payload.repository.owner.login = owner;
     event.payload.repository.name = repo;
 
-    const scope = nock('https://api.github.com')
+    const scope = nock('https://api.github.com');
     await p.receive(event);
 
     if (!scope.isDone()) {
@@ -246,11 +249,11 @@ describe('CIFlowBot Integration Tests', () => {
   test('pull_request.opened event: do not override pre-existing labels', async () => {
     const event = require('./fixtures/pull_request.opened.json');
     event.payload.pull_request.number = pr_number;
-    event.payload.pull_request.labels = [{'name': 'ciflow/eeklo'}];
+    event.payload.pull_request.labels = [{name: 'ciflow/eeklo'}];
     event.payload.repository.owner.login = owner;
     event.payload.repository.name = repo;
 
-    const scope = nock('https://api.github.com')
+    const scope = nock('https://api.github.com');
     await p.receive(event);
 
     if (!scope.isDone()) {
@@ -260,7 +263,6 @@ describe('CIFlowBot Integration Tests', () => {
   });
 
   test('pull_request.opened event: add_default_labels strategy not rolled out', async () => {
-
     const event = require('./fixtures/pull_request.opened.json');
     event.payload.pull_request.user.login = 'rumpelstiltskin';
     event.payload.pull_request.number = pr_number;

--- a/test/ciflow-parse.test.ts
+++ b/test/ciflow-parse.test.ts
@@ -66,13 +66,13 @@ describe('Parse CIFflow issue', () => {
         [
           'opt-out-user',
           {
-            optOut: true,
+            optOut: true
           }
         ],
         [
           'another-opt-out-user',
           {
-            optOut: true,
+            optOut: true
           }
         ]
       ])

--- a/test/common.ts
+++ b/test/common.ts
@@ -3,7 +3,7 @@ import nock from 'nock';
 export function nockTracker(
   contents: string,
   ghaPath: string = 'ezyang/testing-ideal-computing-machine',
-  configContent: string = 'tracking_issue: 6',
+  configContent: string = 'tracking_issue: 6'
 ): void {
   // Setup mock for the "tracking issue" which specifies where
   // CC bot can get labels


### PR DESCRIPTION
Mark `rerun` commands as confusing if it has sub-commands, options or labels that CIFlow does not recognize
    
React with confused status on such commands
    
Addresses user feedback with `CIFlow` +1 comment that had a misspelled label
