### PR TITLE
Fix comment format for disable test issue

### DIFF
--- a/src/verify-disable-test-issue.ts
+++ b/src/verify-disable-test-issue.ts
@@ -115,7 +115,7 @@ export function formValidationComment(
       'title to be of the format: DISABLED test_case_name (test.ClassName), ';
     body += 'for example, `test_cuda_assert_async (__main__.TestCuda)`.\n\n';
   } else {
-    body += `Within ~15 minutes, ${testName} will be disabled in PyTorch CI for `;
+    body += `Within ~15 minutes, \`${testName}\` will be disabled in PyTorch CI for `;
     body +=
       platformsToSkip.length === 0
         ? 'all platforms'

--- a/test/verify-disable-test-issue.test.ts
+++ b/test/verify-disable-test-issue.test.ts
@@ -23,7 +23,7 @@ describe('verify-disable-test-issue', () => {
     expect(comment.includes('<!-- validation-comment-start -->')).toBeTruthy();
     expect(
       comment.includes(
-        '~15 minutes, testMethodName (testClass.TestSuite) will be disabled'
+        '~15 minutes, `testMethodName (testClass.TestSuite)` will be disabled'
       )
     ).toBeTruthy();
     expect(comment.includes('these platforms: win.')).toBeTruthy();
@@ -47,7 +47,7 @@ describe('verify-disable-test-issue', () => {
     expect(comment.includes('<!-- validation-comment-start -->')).toBeTruthy();
     expect(
       comment.includes(
-        '~15 minutes, testMethodName (testClass.TestSuite) will be disabled'
+        '~15 minutes, `testMethodName (testClass.TestSuite)` will be disabled'
       )
     ).toBeTruthy();
     expect(
@@ -70,7 +70,7 @@ describe('verify-disable-test-issue', () => {
     expect(comment.includes('<!-- validation-comment-start -->')).toBeTruthy();
     expect(
       comment.includes(
-        '~15 minutes, testMethodName (testClass.TestSuite) will be disabled'
+        '~15 minutes, `testMethodName (testClass.TestSuite)` will be disabled'
       )
     ).toBeTruthy();
     expect(comment.includes('all platforms.')).toBeTruthy();
@@ -91,7 +91,7 @@ describe('verify-disable-test-issue', () => {
     expect(comment.includes('<!-- validation-comment-start -->')).toBeTruthy();
     expect(
       comment.includes(
-        '~15 minutes, testMethodName (testClass.TestSuite) will be disabled'
+        '~15 minutes, `testMethodName (testClass.TestSuite)` will be disabled'
       )
     ).toBeTruthy();
     expect(comment.includes('all platforms.')).toBeTruthy();


### PR DESCRIPTION
This way the `__main__` will NOT be turned into __main__ in the disable bot comments